### PR TITLE
Shake out circle CI launch issues

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,3 @@
----
 version: 2
 jobs:
   build:


### PR DESCRIPTION
For some reason circleci was failing to detect our config file before I removed
the (totally valid yaml) `---` at the header. It's strange because it works for other
repos (such as the beats repo). Whatever, no point fighting with it. This commit
fixes the issues.