### PR TITLE
Adds cron and more extensible action configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ elastic_curator_etc_dir: /etc/curator
 elastic_curator_esserver: "127.0.0.1"
 elastic_curator_esserver_port: 9200
 
+# Only applicable if the elastic_curator_action var is unmodified and/or
+# added-back in upon modification
+elastic_curator_delete_days: 45
+elastic_curator_delete_prefix: "logstash-"
+
 elastic_curator_config_client:
   hosts:
     - "{{ elastic_curator_esserver }}"
@@ -51,22 +56,23 @@ elastic_curator_action:
   1:
     action: delete_indices
     description: >-
-      Delete indices older than 45 days (based on index name), for logstash-
-      prefixed indices. Ignore the error if the filter does not result in an
-      actionable list of indices (ignore_empty_list) and exit cleanly.
+      Delete indices older than {{ elastic_curator_delete_days }} days (based
+      on index name), for {{elastic_curator_delete_prefix}} prefixed indices.
+      Ignore the error if the filter does not result in an actionable list of
+      indices (ignore_empty_list) and exit cleanly.
     options:
       ignore_empty_list: True
       disable_action: False
     filters:
       - filtertype: pattern
         kind: prefix
-        value: logstash-
+        value: "{{ elastic_curator_delete_prefix }}"
       - filtertype: age
         source: name
         direction: older
         timestring: '%Y.%m.%d'
         unit: days
-        unit_count: 45
+        unit_count: "{{ elastic_curator_delete_days }}"
 ```
 
 Example Playbook

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,6 +14,9 @@ elastic_curator_keyserver: pgp.mit.edu
 elastic_curator_elastic_repo_url: "deb [arch=amd64] http://packages.elastic.co/curator/{{ elastic_curator_version }}/debian stable main"
 
 elastic_curator_etc_dir: /etc/curator
+elastic_curator_act_dir: "{{ elastic_curator_etc_dir }}/actions"
+
+elastic_curator_bin: /usr/bin/curator
 
 elastic_curator_esserver: "127.0.0.1"
 elastic_curator_esserver_port: 9200
@@ -43,24 +46,29 @@ elastic_curator_config_yaml:
 
 # Default action to delete indices
 # www.elastic.co/guide/en/elasticsearch/client/curator/5.1/ex_delete_indices.html
-elastic_curator_action:
-  1:
-    action: delete_indices
-    description: >-
-      Delete indices older than {{ elastic_curator_delete_days }} days (based
-      on index name), for {{elastic_curator_delete_prefix}} prefixed indices.
-      Ignore the error if the filter does not result in an actionable list of
-      indices (ignore_empty_list) and exit cleanly.
-    options:
-      ignore_empty_list: True
-      disable_action: False
-    filters:
-      - filtertype: pattern
-        kind: prefix
-        value: "{{ elastic_curator_delete_prefix }}"
-      - filtertype: age
-        source: name
-        direction: older
-        timestring: '%Y.%m.%d'
-        unit: days
-        unit_count: "{{ elastic_curator_delete_days }}"
+elastic_curator_delete_older_than_x:
+  actions:
+    1:
+      action: delete_indices
+      description: >-
+        Delete indices older than {{ elastic_curator_delete_days }} days (based
+        on index name), for {{elastic_curator_delete_prefix}} prefixed indices.
+        Ignore the error if the filter does not result in an actionable list of
+        indices (ignore_empty_list) and exit cleanly.
+      options:
+        ignore_empty_list: True
+        disable_action: False
+      filters:
+        - filtertype: pattern
+          kind: prefix
+          value: "{{ elastic_curator_delete_prefix }}"
+        - filtertype: age
+          source: name
+          direction: older
+          timestring: '%Y.%m.%d'
+          unit: days
+          unit_count: "{{ elastic_curator_delete_days }}"
+
+# Overload this dictionary to provide alternative curator action files
+elastic_curator_actions:
+  delete_indices: "{{ elastic_curator_delete_older_than_x }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -72,3 +72,17 @@ elastic_curator_delete_older_than_x:
 # Overload this dictionary to provide alternative curator action files
 elastic_curator_actions:
   delete_indices: "{{ elastic_curator_delete_older_than_x }}"
+
+# http://click.pocoo.org/5/python3/#python-3-surrogate-handling
+elastic_curator_cron_default_env:
+  - name: LC_ALL
+    value: C.UTF-8
+  - name: LANG
+    value: C.UTF-8
+
+elastic_curator_cron_jobs:
+  - name: delete_indices
+    minute: 0
+    hour: 1
+    user: nobody
+    file: curator

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,6 +18,11 @@ elastic_curator_etc_dir: /etc/curator
 elastic_curator_esserver: "127.0.0.1"
 elastic_curator_esserver_port: 9200
 
+# Only applicable if the elastic_curator_action var is unmodified and/or
+# added-back in upon modification
+elastic_curator_delete_days: 45
+elastic_curator_delete_prefix: "logstash-"
+
 elastic_curator_config_client:
   hosts:
     - "{{ elastic_curator_esserver }}"
@@ -42,19 +47,20 @@ elastic_curator_action:
   1:
     action: delete_indices
     description: >-
-      Delete indices older than 45 days (based on index name), for logstash-
-      prefixed indices. Ignore the error if the filter does not result in an
-      actionable list of indices (ignore_empty_list) and exit cleanly.
+      Delete indices older than {{ elastic_curator_delete_days }} days (based
+      on index name), for {{elastic_curator_delete_prefix}} prefixed indices.
+      Ignore the error if the filter does not result in an actionable list of
+      indices (ignore_empty_list) and exit cleanly.
     options:
       ignore_empty_list: True
       disable_action: False
     filters:
       - filtertype: pattern
         kind: prefix
-        value: logstash-
+        value: "{{ elastic_curator_delete_prefix }}"
       - filtertype: age
         source: name
         direction: older
         timestring: '%Y.%m.%d'
         unit: days
-        unit_count: 45
+        unit_count: "{{ elastic_curator_delete_days }}"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,8 +1,11 @@
 ---
 - name: Create curator etc dir
   file:
-    path: "{{ elastic_curator_etc_dir }}"
+    path: "{{ elastic_curator_etc_dir }}{{ item }}"
     state: directory
+  with_items:
+    - "/"
+    - "/actions"
 
 - name: Copy curator config
   copy:
@@ -12,11 +15,12 @@
     owner: root
     group: root
 
-- name: Copy curator action file
+- name: Copy curator action file(s)
   copy:
-    content: "{{ elastic_curator_action | to_nice_yaml }}"
-    dest: "{{ elastic_curator_etc_dir }}/actions.yml"
+    content: "{{ elastic_curator_actions[item.key] | to_nice_yaml }}"
+    dest: "{{ elastic_curator_act_dir }}/{{ item.key }}.yml"
     mode: "0644"
     owner: root
     group: root
-    validate: "curator --config {{ elastic_curator_etc_dir }}/curator.yml %s"
+    validate: "{{elastic_curator_bin}} --config {{elastic_curator_etc_dir}}/curator.yml %s"
+  with_dict: "{{ elastic_curator_actions }}"

--- a/tasks/cron.yml
+++ b/tasks/cron.yml
@@ -1,0 +1,25 @@
+---
+- name: Add cron job to run curator tasks
+  cron:
+    name: "{{ item.name }}"
+    job: |
+      {{elastic_curator_bin}} {{elastic_curator_act_dir}}/{{item.name}}.yml --config {{elastic_curator_etc_dir}}/curator.yml
+    special_time: "{{ item.special | default(omit) }}"
+    user: "{{ item.user | default(omit) }}"
+    cron_file: "{{ item.file | default(omit) }}"
+    day: "{{ item.day | default(omit) }}"
+    minute: "{{ item.minute | default(omit) }}"
+    hour: "{{ item.hour | default(omit) }}"
+    env: "{{ item.env | default(omit) }}"
+  with_items: "{{ elastic_curator_cron_jobs }}"
+
+- name: Add cron job environ vars to curator cron jobs
+  cron:
+    name: "{{ item.1.name }}"
+    value: "{{ item.1.value }}"
+    cron_file: "{{ item.0.file | default(omit) }}"
+    user: "{{ item.0.user | default(omit) }}"
+    env: yes
+  with_nested:
+    - "{{ elastic_curator_cron_jobs }}"
+    - "{{ elastic_curator_cron_default_env }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,3 +2,5 @@
 - include: packages.yml
 
 - include: configure.yml
+
+- include: cron.yml


### PR DESCRIPTION
This PR adds two things:
* Cron-jobs - extensible via ansible vars. Kind of a complex lay-out, will definitely take advice on this layout but it seemed to be the fastest way forward while allows configurability downstream. There are many more actions besides delete that curator handles and these shouldnt all be run on the same schedule necessarily.

* Breaks up actions into separate configs - This feature along with the cron job allows a lot of control over when curator tasks are run. ^ Same debate about extensibility vs. ease of management over the variables can be made here.

To test? Does it pass CI? Ehh that doesnt say much since I dont have any testinfra tests. You can run `molecule converge` locally and check out the files layed out under `/etc/curator/actions` as well as cron jobs under `/etc/cron.d/`